### PR TITLE
Ensure dropdowns remember previously submitted value

### DIFF
--- a/views/_components/select.blade.php
+++ b/views/_components/select.blade.php
@@ -17,7 +17,7 @@
     <div class="select-wrapper">
         <select class="form__control" id="{{ $name }}" name="{{ $name }}" {{ isset($disabled) ? 'disabled' : '' }}>
             @foreach ($options as $key => $option)
-                <option value="{{ $key }}" {{ $key === $value ? 'selected' : '' }}>
+                <option value="{{ $key }}" {{ $key == $value ? 'selected' : '' }}>
                     {{ $option }}
                 </option>
             @endforeach


### PR DESCRIPTION
Change to looser comparison for checking numeric values as strings.