### PR TITLE
Added checks to make sure labelText is set before rendering form labels.

### DIFF
--- a/views/_components/file-upload.blade.php
+++ b/views/_components/file-upload.blade.php
@@ -8,9 +8,11 @@
 @extends('form::_components.form-group')
 
 @section('label')
-    <label class="{{ $classes['label'] }}" for="{{ $name }}">
-        {{ $labelText }}
-    </label>
+     @if(isset($labelText))
+        <label class="{{ $classes['label'] }}" for="{{ $name }}">
+            {{ $labelText }}
+        </label>
+    @endif
 @overwrite
 
 @section('input')

--- a/views/_components/grouped-typeahead.blade.php
+++ b/views/_components/grouped-typeahead.blade.php
@@ -16,9 +16,11 @@
 @extends('form::_components.form-group')
 
 @section('label')
-    <label class="{{ $classes['label'] }}" for="{{ $name }}">
-        {{ $labelText }}
-    </label>
+    @if(isset($labelText))
+        <label class="{{ $classes['label'] }}" for="{{ $name }}">
+            {{ $labelText }}
+        </label>
+    @endif
 @overwrite
 
 @section('input')

--- a/views/_components/input.blade.php
+++ b/views/_components/input.blade.php
@@ -12,9 +12,11 @@
 @extends('form::_components.form-group')
 
 @section('label')
-    <label class="{{ $classes['label'] }}" for="{{ $name }}">
-        {{ $labelText }}
-    </label>
+    @if(isset($labelText))
+        <label class="{{ $classes['label'] }}" for="{{ $name }}">
+            {{ $labelText }}
+        </label>
+    @endif
     @if(isset($explanation))
         <p class="font-size-sm">{{ $explanation }}</p>
     @endif

--- a/views/_components/select.blade.php
+++ b/views/_components/select.blade.php
@@ -12,9 +12,11 @@
 @extends('form::_components.form-group')
 
 @section('label')
-    <label class="{{ $classes['label'] }}" for="{{ $name }}">
-        {{ $labelText }}
-    </label>
+    @if(isset($labelText))
+        <label class="{{ $classes['label'] }}" for="{{ $name }}">
+            {{ $labelText }}
+        </label>8
+    @endif
     @if(isset($explanation))
         <p class="font-size-sm">{{ $explanation }}</p>
     @endif

--- a/views/_components/textarea.blade.php
+++ b/views/_components/textarea.blade.php
@@ -11,9 +11,11 @@
 @extends('form::_components.form-group')
 
 @section('label')
-    <label class="{{ $classes['label'] }}" for="{{ $name }}">
-        {{ $labelText }}
-    </label>
+    @if(isset($labelText))
+        <label class="{{ $classes['label'] }}" for="{{ $name }}">
+            {{ $labelText }}
+        </label>
+    @endif
     @if(isset($explanation))
         <p class="font-size-sm">{{ $explanation }}</p>
     @endif


### PR DESCRIPTION
Hey!

First, this is an awesome little package that has already saved me a bunch of time! 

I noticed in the readme that `labelText` should be an optional parameter for each input however I noticed that the following blade templates don't check to see if this is set before calling so if it is omitted from the component arguments an `undefined exception` is thrown:

- File Upload
- Grouped Typehead
- Input
- Select
- Textarea

I appreciate that from an accessibility standpoint labels should not be omitted however I am retrofitting  form elements into an existing application that already has the label markup in place.

I haven't had a chance to run your unit tests to see if it still passes but at a glance it should be OK.